### PR TITLE
use protocol https to access geonames server

### DIFF
--- a/app/public/js/jquery.geonames.js
+++ b/app/public/js/jquery.geonames.js
@@ -30,7 +30,7 @@
 	my.defaultCountryCode = 'CH';
 	my.defaultLanguage = 'en';
 	my.geoNamesApiServer = 'ws.geonames.net';
-	my.geoNamesProtocol = 'http';
+	my.geoNamesProtocol = 'https';
 
 	my.featureClass = {
 		AdministrativeBoundaryFeatures: 'A',


### PR DESCRIPTION
use the protocol `https` for requests to the geonames server 

using tangoh now, we get an error  when trying to fill a location in a geoname field:
![Capture d’écran de 2021-12-17 01-02-41](https://user-images.githubusercontent.com/3933654/146466866-950e6498-0e51-401d-975f-fdb72aa1a618.png)

the browser blocks the request because it is send from a `https` page toward a `http` site (`strict-origin-when-cross-origin`)
